### PR TITLE
Fixes issue with westpac login treating headless chrome incompatible

### DIFF
--- a/.changeset/silent-rats-retire.md
+++ b/.changeset/silent-rats-retire.md
@@ -1,0 +1,5 @@
+---
+"ynab-sync-westpac-au": patch
+---
+
+Fixes issue with Westpac login treating headless chrome as an incompatible browser

--- a/packages/westpac-au/src/export/login.ts
+++ b/packages/westpac-au/src/export/login.ts
@@ -51,6 +51,13 @@ export async function login(
     loginTimeoutInMs: 2000,
   }
 ): Promise<void> {
+  // Westpac attempts to detect browser compatibility by checking the user agent and redirects to an error page if it's not compatible.
+  // When running in headless mode the user agent string contains "HeadlessChrome" which Westpac detects as incompatible,
+  // so we'll replace the user agent string with a compatible one.
+  await page.setUserAgent(
+    (await page.browser().userAgent()).replace("HeadlessChrome", "Chrome")
+  );
+
   await page.goto(
     "https://banking.westpac.com.au/wbc/banking/handler?TAM_OP=login&segment=personal&logout=false"
   );

--- a/packages/westpac-au/src/sync/syncTransactions.ts
+++ b/packages/westpac-au/src/sync/syncTransactions.ts
@@ -91,8 +91,8 @@ export const syncTransactions = async (
   const outputFilePath = await exportTransactions(
     page,
     params.westpacAccount.accountName,
-    params.options.startDate,
-    params.options.endDate,
+    startDate,
+    endDate,
     undefined,
     {
       debug: params.options.debug || false,


### PR DESCRIPTION
Westpac has started treating headless chrome as an incompatible browser due to the user agent containing "HeadlessChrome". This PR fixes this by replacing the user agent string to indicate that it is "Chrome" even though it's headless.