### PR TITLE
Removes use of account type to modify St George transaction amounts

### DIFF
--- a/.changeset/big-pugs-move.md
+++ b/.changeset/big-pugs-move.md
@@ -1,0 +1,5 @@
+---
+"ynab-sync-st-george-au": patch
+---
+
+Removes use the accountType to modify debit/credit amounts as transaction exports have changed

--- a/packages/st-george-au/src/sync/syncTransactions.ts
+++ b/packages/st-george-au/src/sync/syncTransactions.ts
@@ -125,15 +125,9 @@ export const syncTransactions = async (
     getDate: (input: any) => parse(input.Date, "dd/MM/yyyy", new Date()),
     getAmount: (input: any) => {
       if (input.Debit) {
-        return (
-          input.Debit *
-          (params.stGeorgeAccount.accountType === AccountType.Debit ? -1 : 1)
-        );
+        return input.Debit;
       } else {
-        return (
-          input.Credit *
-          (params.stGeorgeAccount.accountType === AccountType.Credit ? -1 : 1)
-        );
+        return input.Credit;
       }
     },
     getMemo: (input: any) => undefined,

--- a/packages/st-george-au/src/sync/syncTransactions.ts
+++ b/packages/st-george-au/src/sync/syncTransactions.ts
@@ -125,7 +125,7 @@ export const syncTransactions = async (
     getDate: (input: any) => parse(input.Date, "dd/MM/yyyy", new Date()),
     getAmount: (input: any) => {
       if (input.Debit) {
-        return input.Debit;
+        return input.Debit * -1;
       } else {
         return input.Credit;
       }


### PR DESCRIPTION
Currently the `--account-type` option is used to modify when the amounts in the debit/credit columns for St George transactions. This was put in place as the amounts would be in different columns to what you would usually expect depending on the type of account e.g. a debit account vs a loan account. Not 100% sure the reason, but it seems like something has recently changed with the exports and the amount appears in the columns how you would expect e.g. a negative amount is in Debit and positive amount is in Credit.

This PR removes the use of the account type option. If this proves to be the behaviour going forward then the option can be removed.